### PR TITLE
Issue #2: Count parameters per function

### DIFF
--- a/metrics.md
+++ b/metrics.md
@@ -15,7 +15,8 @@ e.g. from awk.
 * Number of characters
 * Number of lines, minimum, mean, maximum, standard deviation of line length
 * Number of empty lines (Lines which contain only whitespace characters).
-* Number of functions (A function is considered to start with `{` at column 1)
+* Number of function declarations (prototypes).
+* Number of function definitons (A function with a body).
 * Number of statements, minimum, mean, maximum, standard deviation of statement nesting
 * Number of declarations with internal linkage (`static`) visibility
 * Number of `const` keywords

--- a/metrics.md
+++ b/metrics.md
@@ -17,6 +17,7 @@ e.g. from awk.
 * Number of empty lines (Lines which contain only whitespace characters).
 * Number of function declarations (prototypes).
 * Number of function definitons (A function with a body).
+* Number of functions, minimum, mean, maximum, standard deviation of function parameters.
 * Number of statements, minimum, mean, maximum, standard deviation of statement nesting
 * Number of declarations with internal linkage (`static`) visibility
 * Number of `const` keywords

--- a/src/CMetricsCalculator.cpp
+++ b/src/CMetricsCalculator.cpp
@@ -144,7 +144,9 @@ CMetricsCalculator::newline(bool in_non_code_block)
 	saw_non_semicolon_keyword = false;
 	saw_unindent = false;
 	saw_comment = false;
-	saw_cpp_directive = false;
+	// Reset C preprocessor directive if line does not end with a backslash.
+	if (c != '\\' && saw_cpp_directive)
+		saw_cpp_directive = false;
 	line_nesting = nesting.get_nesting_level();
 }
 

--- a/src/CMetricsCalculator.h
+++ b/src/CMetricsCalculator.h
@@ -45,6 +45,7 @@ private:
 	/** Bracket balance for control statememts. */
 	int stmt_bracket_balance;
 	int line_bracket_balance;	// Bracket balance for each line
+	int func_bracket_balance;	// Bracket balance for functions
 	int line_nesting;		// Nesting of current line
 	/** Indentation of preceding indented line. */
 	int previous_indentation;
@@ -64,14 +65,16 @@ private:
 	void keyword_style_left_space(char before);
 	/** Called at every encountered newline */
 	void newline(bool in_non_code_block = false);
+	/** Get last non space char until the terminated char. */
+	char get_first_pre_non_space_char(char terminated_c);
 public:
 	CMetricsCalculator(std::istream &s = std::cin) : src(s),
 	top_level_depth(0), current_depth(0),
 	scan_cpp_directive(false), scan_cpp_line(false),
 	in_function(false), identifier_func(false), in_dox_comment(false),
 	chars_read_at_bol(0), stmt_bracket_balance(0), line_bracket_balance(0),
-	line_nesting(0), previous_indentation(0), continuation(false),
-	saw_non_semicolon_keyword(false), saw_unindent(false),
+	func_bracket_balance(0), line_nesting(0), previous_indentation(0),
+	continuation(false), saw_non_semicolon_keyword(false), saw_unindent(false),
 	saw_comment(false), saw_cpp_directive(false), indentation_list(false) {}
 	void calculate_metrics() {
 		calculate_metrics_loop();

--- a/src/CMetricsCalculator.h
+++ b/src/CMetricsCalculator.h
@@ -36,7 +36,9 @@ private:
 	bool scan_cpp_line;		// Line after a C preprocessor #
 	void calculate_metrics_loop();
 	bool calculate_metrics_switch();
-	bool in_function;		// True when scanning functions
+	bool in_function;		// True when scanning body of functions.
+	/** True if processing an identifier which describes a function. */
+	bool identifier_func;
 	bool in_dox_comment;		// True if processing a DOxygen comment
 	int chars_read_at_bol;		// Characters that were read
 					// at the beginning of a line
@@ -66,7 +68,7 @@ public:
 	CMetricsCalculator(std::istream &s = std::cin) : src(s),
 	top_level_depth(0), current_depth(0),
 	scan_cpp_directive(false), scan_cpp_line(false),
-	in_function(false), in_dox_comment(false),
+	in_function(false), identifier_func(false), in_dox_comment(false),
 	chars_read_at_bol(0), stmt_bracket_balance(0), line_bracket_balance(0),
 	line_nesting(0), previous_indentation(0), continuation(false),
 	saw_non_semicolon_keyword(false), saw_unindent(false),

--- a/src/CMetricsCalculatorTest.h
+++ b/src/CMetricsCalculatorTest.h
@@ -30,6 +30,7 @@ class CMetricsCalculatorTest : public CppUnit::TestFixture {
 	CPPUNIT_TEST(testNEmptyLine);
 	CPPUNIT_TEST(testNFunctionDefinition);
 	CPPUNIT_TEST(testNFunctionDefinitionAndDeclaration);
+	CPPUNIT_TEST(testFunctionNParams);
 	CPPUNIT_TEST(testNStatement);
 	CPPUNIT_TEST(testStatementNesting);
 	CPPUNIT_TEST(testStatementNestingTwoFunction);
@@ -118,6 +119,16 @@ public:
 		const QualityMetrics& qm(calc.get_metrics());
 		CPPUNIT_ASSERT_EQUAL(qm.get_nfunction_def(), 1);
 		CPPUNIT_ASSERT_EQUAL(qm.get_nfunction_decl(), 1);
+	}
+
+	void testFunctionNParams() {
+		std::stringstream str("int foo();\nvoid bar(int b) {}\n"
+				"int blah(int x, int a);");
+		CMetricsCalculator calc(str);
+		calc.calculate_metrics();
+		const QualityMetrics& qm(calc.get_metrics());
+		CPPUNIT_ASSERT_EQUAL(qm.get_function_params().get_count(), 3);
+		CPPUNIT_ASSERT_EQUAL(qm.get_function_params().get_mean(), 1.0);
 	}
 
 	void testHalsteadOperator() {

--- a/src/CMetricsCalculatorTest.h
+++ b/src/CMetricsCalculatorTest.h
@@ -28,7 +28,8 @@ class CMetricsCalculatorTest : public CppUnit::TestFixture {
 	CPPUNIT_TEST_SUITE(CMetricsCalculatorTest);
 	CPPUNIT_TEST(testCtor);
 	CPPUNIT_TEST(testNEmptyLine);
-	CPPUNIT_TEST(testNFunction);
+	CPPUNIT_TEST(testNFunctionDefinition);
+	CPPUNIT_TEST(testNFunctionDefinitionAndDeclaration);
 	CPPUNIT_TEST(testNStatement);
 	CPPUNIT_TEST(testStatementNesting);
 	CPPUNIT_TEST(testStatementNestingTwoFunction);
@@ -100,12 +101,23 @@ public:
 		CPPUNIT_ASSERT_EQUAL(qm.get_nempty_line(), 2);
 	}
 
-	void testNFunction() {
-		std::stringstream str("foo()\n{((??}\nstruct bar {}");
+	void testNFunctionDefinition() {
+		std::stringstream str("foo()\n{((??}\nstruct bar {}\n bar_func() {}");
 		CMetricsCalculator calc(str);
 		calc.calculate_metrics();
 		const QualityMetrics& qm(calc.get_metrics());
-		CPPUNIT_ASSERT_EQUAL(qm.get_nfunction(), 1);
+		CPPUNIT_ASSERT_EQUAL(qm.get_nfunction_def(), 2);
+		CPPUNIT_ASSERT_EQUAL(qm.get_nfunction_decl(), 0);
+	}
+
+	void testNFunctionDefinitionAndDeclaration() {
+		std::stringstream str("#define FOO(x) blah(x);\n int foo();\n"
+				"int bar(int x, int z) {}");
+		CMetricsCalculator calc(str);
+		calc.calculate_metrics();
+		const QualityMetrics& qm(calc.get_metrics());
+		CPPUNIT_ASSERT_EQUAL(qm.get_nfunction_def(), 1);
+		CPPUNIT_ASSERT_EQUAL(qm.get_nfunction_decl(), 1);
 	}
 
 	void testHalsteadOperator() {

--- a/src/FunctionSignature.h
+++ b/src/FunctionSignature.h
@@ -1,0 +1,35 @@
+/*-
+ * Copyright 2017 Diomidis Spinellis, Thodoris Sotiropoulos
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#ifndef FUNCTIONSIGNATURE_H
+#define FUNCTIONSIGNATURE_H
+
+
+/** Information about the signature of a function. */
+class FunctionSignature {
+private:
+	int nparams;
+public:
+	FunctionSignature() { reset(); }
+
+	void reset() { nparams = 0; }
+
+	void add_param() { nparams++; }
+
+	int get_nparams() { return nparams; }
+
+};
+#endif /* FUNCTIONSIGNATURE_H */

--- a/src/FunctionSignatureTest.h
+++ b/src/FunctionSignatureTest.h
@@ -1,0 +1,43 @@
+/*-
+ * Copyright 2017 Diomidis Spinellis, Thodoris Sotiropoulos
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#ifndef FUNCTIONSIGNATURETEST_H
+#define FUNCTIONSIGNATURETEST_H
+
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "FunctionSignature.h"
+
+class FunctionSignatureTest : public CppUnit::TestFixture {
+	CPPUNIT_TEST_SUITE(FunctionSignatureTest);
+	CPPUNIT_TEST(testCtor);
+	CPPUNIT_TEST(testAddParam);
+	CPPUNIT_TEST_SUITE_END();
+public:
+	void testCtor() {
+		FunctionSignature func_sign;
+		CPPUNIT_ASSERT_EQUAL(func_sign.get_nparams(), 0);
+	}
+
+	void testAddParam() {
+		FunctionSignature func_sign;
+		func_sign.add_param();
+		CPPUNIT_ASSERT_EQUAL(func_sign.get_nparams(), 1);
+		func_sign.add_param();
+		CPPUNIT_ASSERT_EQUAL(func_sign.get_nparams(), 2);
+	}
+};
+#endif /* FUNCTIONSIGNATURETEST_H */

--- a/src/QualityMetrics.cpp
+++ b/src/QualityMetrics.cpp
@@ -104,9 +104,13 @@ operator <<(std::ostream& o, const QualityMetrics &q) {
 		ANNOTATE(" empty: " <<)
 		q.get_nempty_line() << '\t' <<
 
-		// VAL: Number of functions (A function is considered to start with `{` at column 1)
-		ANNOTATE(" fun: " <<)
-		q.get_nfunction() << '\t' <<
+		// VAL: Number of function declarations (prototypes).
+		ANNOTATE(" func decl: " <<)
+		q.get_nfunction_decl() << '\t' <<
+
+		// VAL: Number of function definitons (A function with a body).
+		ANNOTATE(" func def: " <<)
+		q.get_nfunction_def() << '\t' <<
 
 		// VAL: Number of statements, minimum, mean, maximum, standard deviation of statement nesting
 		ANNOTATE(" nest: " <<)

--- a/src/QualityMetrics.cpp
+++ b/src/QualityMetrics.cpp
@@ -112,6 +112,10 @@ operator <<(std::ostream& o, const QualityMetrics &q) {
 		ANNOTATE(" func def: " <<)
 		q.get_nfunction_def() << '\t' <<
 
+		// VAL: Number of functions, minimum, mean, maximum, standard deviation of function parameters.
+		ANNOTATE(" func params " <<)
+		q.get_function_params() << '\t' <<
+
 		// VAL: Number of statements, minimum, mean, maximum, standard deviation of statement nesting
 		ANNOTATE(" nest: " <<)
 		q.get_statement_nesting() << '\t' <<

--- a/src/QualityMetrics.h
+++ b/src/QualityMetrics.h
@@ -25,6 +25,7 @@
 
 #include "Cyclomatic.h"
 #include "Descriptive.h"
+#include "FunctionSignature.h"
 #include "Halstead.h"
 
 /** Keep taly of quality metrics */
@@ -71,6 +72,9 @@ private:
 	Descriptive<int> identifier_length;
 	Descriptive<int> unique_identifier_length;
 
+	/** Holds information about the signature of a function. */
+	FunctionSignature function_tracker;
+	Descriptive<int> function_params;  // Number of parameters per function
 	Descriptive<int> statement_nesting;	// Statement nesting
 	Descriptive<double> halstead;		// Halstead complexity
 	Halstead halstead_tracker;
@@ -180,10 +184,18 @@ public:
 	void add_style_hint(enum StyleHint num) { nstyle_hint[num]++; }
 #endif
 	void add_function_decl() { nfunction_decl++; }
+	void add_function_param() {
+		function_tracker.add_param();
+	}
+	void begin_function_decl() { function_tracker.reset(); }
 	void begin_function_def() {
+		end_function_decl();
 		halstead_tracker.reset();
 		cyclomatic_tracker.reset();
 		nfunction_def++;
+	}
+	void end_function_decl() {
+		function_params.add(function_tracker.get_nparams());
 	}
 	void end_function_def() {
 		halstead.add(halstead_tracker.complexity());
@@ -231,6 +243,9 @@ public:
 	const Descriptive<int> &get_statement_nesting() const {
 		return statement_nesting;
 	}
+	int get_function_params() {
+		return function_tracker.get_nparams();
+	}
 	int get_ninternal() const { return ninternal; }
 	int get_nconst() const { return nconst; }
 	int get_nenum() const { return nenum; }
@@ -265,6 +280,7 @@ public:
 	int get_nfun_cpp_directive() const { return nfun_cpp_directive; }
 	int get_nfun_cpp_conditional() const { return nfun_cpp_conditional; }
 
+	const Descriptive<int>& get_function_params() const { return function_params; }
 	const Descriptive<double>& get_halstead() const { return halstead; }
 	const Descriptive<double>& get_cyclomatic() const { return cyclomatic; }
 	const Descriptive<double>& get_indentation_spacing() const {

--- a/src/QualityMetrics.h
+++ b/src/QualityMetrics.h
@@ -39,7 +39,8 @@ private:
 	int nboilerplate_comment_char;	// Number of boilerplate (license) comment characters
 	int ndox_comment;		// Number of DOxygen comments
 	int ndox_comment_char;		// Number of DOxygen comment characters
-	int nfunction;			// Number of functions
+	int nfunction_decl;		// Number of function declarations
+	int nfunction_def;		// Number of function defintions
 	int ncpp_directive;		// Number of C preprocessor directives
 
 	int ncpp_include;		// Number of include directives
@@ -129,7 +130,7 @@ public:
 
 	QualityMetrics() :
 		nempty_line(0), ncomment(0), ncomment_char(0), nboilerplate_comment_char(0),
-		ndox_comment(0), ndox_comment_char(0), nfunction(0),
+		ndox_comment(0), ndox_comment_char(0), nfunction_decl(0), nfunction_def(0),
 		ncpp_directive(0), ncpp_include(0), ninternal(0), nconst(0),
 		nenum(0), ngoto(0), ninline(0), nnoalias(0), nregister(0),
 		nrestrict(0), nsigned(0), nstruct(0), ntypedef(0), nunion(0),
@@ -178,12 +179,13 @@ public:
 #else
 	void add_style_hint(enum StyleHint num) { nstyle_hint[num]++; }
 #endif
-	void begin_function() {
+	void add_function_decl() { nfunction_decl++; }
+	void begin_function_def() {
 		halstead_tracker.reset();
 		cyclomatic_tracker.reset();
-		nfunction++;
+		nfunction_def++;
 	}
-	void end_function() {
+	void end_function_def() {
 		halstead.add(halstead_tracker.complexity());
 		cyclomatic.add(cyclomatic_tracker.extended_complexity());
 	}
@@ -224,7 +226,8 @@ public:
 	int get_nempty_line() const {
 		return nempty_line;
 	}
-	int get_nfunction() const { return nfunction; }
+	int get_nfunction_decl() const { return nfunction_decl; }
+	int get_nfunction_def() const { return nfunction_def; }
 	const Descriptive<int> &get_statement_nesting() const {
 		return statement_nesting;
 	}

--- a/src/UnitTests.cpp
+++ b/src/UnitTests.cpp
@@ -23,6 +23,7 @@
 #include "CMetricsCalculatorTest.h"
 #include "CyclomaticTest.h"
 #include "DescriptiveTest.h"
+#include "FunctionSignatureTest.h"
 #include "HalsteadTest.h"
 #include "NestingLevelTest.h"
 #include "QualityMetricsTest.h"
@@ -39,6 +40,7 @@ main(int argc, char *argv[])
 	runner.addTest(CMetricsCalculatorTest::suite());
 	runner.addTest(CyclomaticTest::suite());
 	runner.addTest(DescriptiveTest::suite());
+	runner.addTest(FunctionSignatureTest::suite());
 	runner.addTest(HalsteadTest::suite());
 	runner.addTest(NestingLevelTest::suite());
 	runner.addTest(QualityMetricsTest::suite());

--- a/src/make-header.sh
+++ b/src/make-header.sh
@@ -23,10 +23,11 @@ do
 done |
 # Convert _count metrics to the value measured
 sed '
+s/function_params_count/nfunction/
 s/line_length_count/nline/
 s/statement_nesting_count/nstatement/
-s/halstead_count/nfunction/
-s/cyclomatic_count/nfunction2/
+s/halstead_count/nfunction_def/
+s/cyclomatic_count/nfunction_def2/
 s/identifier_length_count/nidentifier/
 s/unique_identifier_length_count/nunique_identifier/
 '


### PR DESCRIPTION
This pull request also changes the heuristic of function detection. Specifically:

An identifier which is followed by '(' is considered a function. This
can be a function declaration (e.g. prototype):

```c
int foo(int x);
```

or a function definition (with body):
```c
int foo(int x)
{
    // Code here ...
}
```

This commit handles both cases and it introduces two metrics:
- Number of function declarations (prototypes).
- Number of function definitions.