### PR TITLE
Recreate metric files when QualityMetric.h is updated

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,11 +31,11 @@ QualityMetricNames.h: QualityMetrics.h metric-names.sed
 	sh make-metrics-list.sh >$@
 
 # Tab-separated, ending with a newline
-header.tab: make-header.sh QualityMetrics.cpp
+header.tab: make-header.sh QualityMetrics.h QualityMetrics.cpp
 	sh make-header.sh | tr ' \n' '\t\t' | sed 's/\t$$/\n/' >$@
 
 # Numbered lines
-header.txt: make-header.sh QualityMetrics.cpp
+header.txt: make-header.sh QualityMetrics.h QualityMetrics.cpp
 	sh make-header.sh | tr ' \t' '\n\n' | cat -n >$@
 
 clean:


### PR DESCRIPTION
That's a minor fix on make rules.

Apart from `QualityMetric.cpp`, the `make-header.sh` script relies on the corresponding header file to generate the `header.tab` and `header.txt` files.

So, this commit adds this dependency.