### PR TITLE
Add dependencies of qmcalc.o object file

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -44,3 +44,4 @@ clean:
 
 # Pull-in dependencies generated with -MD
 -include $(OBJS:.o=.d)
+-include qmcalc.d


### PR DESCRIPTION
The Make variable `$OBJS` does not contain the object file `qmcalc.o`. IAs a result, incremental builds do not consider the dependencies of this object file.