### PR TITLE
Add install rule in Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ This will also generate the files `header.tab` and `header.txt`,
 which can be used for loading the output into other programs
 for further processing.
 
+### Install
+
+`cd src && make install`
+
 ## Running
 * The  *cmcalc* program can process its standard input or report metrics on each of the specified files
 * The *showstyle* wrapper takes as a single argument a directory, and reports the metrics for each C file in the directory
@@ -48,7 +52,7 @@ for further processing.
     * the metric's ordinal number,
     * the sum of the metric's values over all files, and
     * the percentage of files for which the metric is non-zero.
-    
+
 ## Further reading
 The style checks performed are based on the following guidelines.
 * [Google](http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml)

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,8 @@ else
 CXXFLAGS+=-O2
 endif
 
+INSTALL_PREFIX?=/usr/local
+
 all: qmcalc ../metrics.md header.tab header.txt
 
 HFILES=$(wildcard *.h)
@@ -37,6 +39,9 @@ header.tab: make-header.sh QualityMetrics.h QualityMetrics.cpp
 # Numbered lines
 header.txt: make-header.sh QualityMetrics.h QualityMetrics.cpp
 	sh make-header.sh | tr ' \t' '\n\n' | cat -n >$@
+
+install: qmcalc
+	install qmcalc "$(INSTALL_PREFIX)/bin/qmcalc"
 
 clean:
 	rm -f *.o *.d *.exe qmcalc UnitTests QualityMetricNames.h \


### PR DESCRIPTION
This PR adds install rule in Makefile and instructions for installing `qmcalc` in README. 